### PR TITLE
Fix Windows CI

### DIFF
--- a/.github/workflows/rebuildElectron.yml
+++ b/.github/workflows/rebuildElectron.yml
@@ -86,7 +86,7 @@ jobs:
     name: Rebuild Windows
     strategy:
       matrix:
-        os: [windows-2016]
+        os: [windows-2019]
         arch: [x86, x64]
       fail-fast: false
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Update Windows 2016 CI to 2019.
Github has deprecated Windows 2016