### PR TITLE
Bump macOS runner version

### DIFF
--- a/.github/workflows/rebuildElectron.yml
+++ b/.github/workflows/rebuildElectron.yml
@@ -168,7 +168,7 @@ jobs:
     name: Rebuild macOS
     strategy:
       matrix:
-        os: [macOS-10.15]
+        os: [macOS-11]
         arch: [x64]
       fail-fast: false
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
macos 10.15 is deperecated and currently performing scheduled brownouts.
ex: https://github.com/Axosoft/electron-npg-automator/actions/runs/2750014314

https://github.com/actions/virtual-environments/issues/5583